### PR TITLE
chore: remove github token for tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,6 @@ jobs:
       - name: 🧾 Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_BASIC }}
           lfs: true
           submodules: 'recursive'
 


### PR DESCRIPTION
Updated the checkout action in the tests workflow so it doesn't require an unnecessary Github token.