### PR TITLE
chore: remove github token for auto-release

### DIFF
--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -33,8 +33,6 @@ jobs:
       - name: 🧾 Checkout
         uses: actions/checkout@v4
         with:
-          # Use your GitHub Personal Access Token variable here.
-          token: ${{ secrets.GH_BASIC }}
           lfs: true
           submodules: 'recursive'
 


### PR DESCRIPTION
Updated the checkout action in the auto-release workflow so it doesn't require an unnecessary Github token.