### PR TITLE
chore: don't run release action on forks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
   release:
     name: '📦 Release'
     runs-on: ubuntu-latest
+    if: github.repository == 'chickensoft-games/GameTools'
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_NOLOGO: true


### PR DESCRIPTION
Forks of the main repository can satisfy the preconditions in the auto_release release workflow, triggering an attempted release. (E.g., when the fork is synced to upstream, if dependencies have been updated in the upstream repository, the preconditions will be satisfied.) The release process likely won't work, since it requires github and nuget tokens, but it creates a failed workflow run and may trigger spurious notifications to developers.

![Screenshot 2025-05-30 141613](https://github.com/user-attachments/assets/7729194a-4dc9-4dd5-b94a-238ee21e3e9f)

This change updates the release workflow to require that it is executed in the original Chickensoft repository as a precondition to prevent these failed release runs.