### PR TITLE
fix: fallback for nonexistent window override size

### DIFF
--- a/Chickensoft.GameTools/src/displays/Display.cs
+++ b/Chickensoft.GameTools/src/displays/Display.cs
@@ -83,14 +83,25 @@ public static class Display {
     GetDisplayNativeResolution { get; set; } =
       GetDisplayNativeResolutionDefault;
 
-  internal static Vector2I ProjectWindowSize => new(
-    ProjectSettings.GetSetting(
-      "display/window/size/window_width_override"
-    ).AsInt32(),
-    ProjectSettings.GetSetting(
-      "display/window/size/window_height_override"
-    ).AsInt32()
-  );
+  internal static Vector2I ProjectWindowSize {
+    get {
+      var windowSize = new Vector2I(
+        ProjectSettings.GetSetting(
+          "display/window/size/window_width_override"
+        ).AsInt32(),
+        ProjectSettings.GetSetting(
+          "display/window/size/window_height_override"
+        ).AsInt32()
+      );
+      if (windowSize.X == 0 || windowSize.Y == 0) {
+        var viewportSize = ProjectViewportSize;
+        windowSize.X = windowSize.X == 0 ? viewportSize.X : windowSize.X;
+        windowSize.Y = windowSize.Y == 0 ? viewportSize.Y : windowSize.Y;
+      }
+      return windowSize;
+    }
+  }
+
 
   internal static Vector2I ProjectViewportSize => new(
     ProjectSettings.GetSetting("display/window/size/viewport_width").AsInt32(),


### PR DESCRIPTION
Fixes chickensoft-games/GodotGame#156.

When the window override size does not exist (i.e., is set to 0), use the project's viewport-size setting as a fallback.

Untested on Linux and MacOS, but seems to preserve behavior on Windows, vs setting the window size override to the same values as the viewport size. (Tested on Windows 11, with a 4K monitor at 150% scale and a 1080p monitor at 100%.)