### PR TITLE
fix: Only apply ContentScaleFactor when using UIProportional

### DIFF
--- a/Chickensoft.GameTools/src/displays/Display.cs
+++ b/Chickensoft.GameTools/src/displays/Display.cs
@@ -235,11 +235,11 @@ public static class Display
           window.ContentScaleMode = Window.ContentScaleModeEnum.CanvasItems;
           window.ContentScaleAspect = Window.ContentScaleAspectEnum.Expand;
         }
+        window.ContentScaleFactor = scaleInfo.ContentScaleFactor;
 
         break;
     }
 
-    window.ContentScaleFactor = scaleInfo.ContentScaleFactor;
     window.Size = sizeInfo.Size;
     window.MinSize = sizeInfo.MinSize;
     window.MaxSize = sizeInfo.MaxSize;


### PR DESCRIPTION
This has been bothering me a while, but I couldn't quite pin what it was until now.

When using LookGood with the following options:
```C#
window.LookGood(
	WindowScaleBehavior.UIFixed,
	Display.FullHD,
	sizeInfo: new WindowSizeInfo(Display.FullHD, Display.HD, Display.UHD4k)
);
```

I expect the project to use a theme resolution of 1920x1080, the Window size to be 1920x1080, and everything should fit 1 to 1, but it doesn't on HiDPI monitors. At the moment it uses the Content Scale Factor derived from the ScaleInfo, which causes the UI elements to overflow unexpectedly.

One could just manually create the scaleInfo like so `window.GetWindowScaleInfo(Display.FullHD) with { ContentScaleFactor = 1 }` but I think this defeats the purpose of UIFixed.

This change makes it so that ContentScaleFactor is only set when using UIProportional and not when using UIFixed.